### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Collections.Generic/Pure.Collections.Generic.csproj
+++ b/src/Pure.Collections.Generic/Pure.Collections.Generic.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.1.0-preview.3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Collections.Generic</PackageId>


### PR DESCRIPTION
Closes #61

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.